### PR TITLE
fix biome for newer transient versions

### DIFF
--- a/biome-query.el
+++ b/biome-query.el
@@ -1016,16 +1016,17 @@ SECTION is a form as defined in `biome-api-parse--page'."
 
 (transient-define-prefix biome-query (callback)
   ["Open Meteo Data"
+   :class transient-column
    :setup-children
    (lambda (_)
-     (cl-loop for (name . params) in biome-api-data
-              collect (transient-parse-suffix
-                       transient--prefix
-                       `(,(alist-get :key params)
-                         ,name
-                         (lambda () (interactive)
-                           (biome-query--section-open ,name))
-                         :transient transient--do-stack))))]
+     (transient-parse-suffixes
+      'transient--prefix
+      (cl-loop for (name . params) in biome-api-data
+       collect `(,(alist-get :key params)
+                  ,name
+                  (lambda () (interactive)
+                    (biome-query--section-open ,name))
+                  :transient transient--do-stack))))]
   ["Actions"
    :class transient-row
    ("r" "Resume" biome-resume :transient transient--do-replace)


### PR DESCRIPTION
I ran into problems using Biome with newer versions of Transient. `transient-parse-suffix` expects the prefix (`transient--prefix`) to be quoted. This error is the same as https://github.com/magit/transient/issues/277. The problem and further advice are explained by https://github.com/magit/transient/issues/277#issuecomment-1965524550. The advice and the missing quote is implemented by this PR.

I roughly tested this PR with

- Emacs 29.2 with Transient (built-in)
- Emacs 30 with Transient (Melpa 20240226.2332)

## Note

If you are using the newest version of Transient (Melpa 20240226.2332) and the current version of Biome (Melpa 20240128.1235), then you will now get the fowlloing backtrace.

```elisp
Debugger entered--Lisp error: (cl-assertion-failed ((and prefix (symbolp prefix)) nil))
  transient--exit-and-debug(error (cl-assertion-failed ((and prefix (symbolp prefix)) nil)))
  cl--assertion-failed((and prefix (symbolp prefix)))
  transient-parse-suffix(#<transient-prefix transient-prefix-d9d90f> ("ww" "Weather Forecast" (lambda nil (interactive) (biome-query--section-open "Weather Forecast")) :transient transient--do-stack))
  #f(compiled-function (_) #<bytecode 0x188cc00303e7caf2>)(nil)
  transient-setup-children(#<transient-column transient-column-d9d95a> nil)
  transient--init-group(nil [1 transient-column (:description "Open Meteo Data" :setup-children #f(compiled-function (_) #<bytecode 0x188cc00303e7caf2>)) nil])
  transient--init-child(nil [1 transient-column (:description "Open Meteo Data" :setup-children #f(compiled-function (_) #<bytecode 0x188cc00303e7caf2>)) nil])
  #f(compiled-function (c) #<bytecode 0x12277a62df0ed157>)([1 transient-column (:description "Open Meteo Data" :setup-children #f(compiled-function (_) #<bytecode 0x188cc00303e7caf2>)) nil])
  cl-mapcan(#f(compiled-function (c) #<bytecode 0x12277a62df0ed157>) ([1 transient-column (:description "Open Meteo Data" :setup-children #f(compiled-function (_) #<bytecode 0x188cc00303e7caf2>)) nil] [1 transient-row (:description "Actions") ((1 transient-suffix (:key "r" :description "Resume" :command biome-resume :transient transient--do-replace)) (1 transient-suffix (:key "q" :description "Quit" :command transient-quit-one)))] [1 transient-columns (:hide #f(compiled-function () #<bytecode -0x172e7fbee64d963f>)) ([1 transient-column (:description "Value commands") ((1 transient-suffix (:key "C-x s  " :description "Set" :command transient-set)) (1 transient-suffix (:key "C-x C-s" :description "Save" :command transient-save)) (1 transient-suffix (:key "C-x C-k" :description "Reset" :command transient-reset)) (1 transient-suffix (:key "C-x p  " :description "Previous value" :command transient-history-prev)) (1 transient-suffix (:key "C-x n  " :description "Next value" :command transient-history-next)))] [1 transient-column (:description "Sticky commands") ((1 transient-suffix (:key "C-g" :description "Quit prefix or transient" :command transient-quit-one)) (1 transient-suffix (:key "C-q" :description "Quit transient stack" :command transient-quit-all)) (1 transient-suffix (:key "C-z" :description "Suspend transient stack" :command transient-suspend)))] [1 transient-column (:description "Customize") ((1 transient-suffix (:key "C-x t" :command transient-toggle-common :description #f(compiled-function () #<bytecode -0x1521b14a25ae9648>))) (1 transient-suffix (:key "C-x l" :description "Show/hide suffixes" :command transient-set-level)) (1 transient-suffix (:key "C-x a" :command transient-toggle-level-limit)))])]))
  transient--init-suffixes(biome-query)
  transient--init-objects(biome-query nil nil)
  transient-setup(biome-query)
  biome-query(#<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_15>)
  biome()
  funcall-interactively(biome)
  command-execute(biome record)
  execute-extended-command(nil "biome" "biome")
  funcall-interactively(execute-extended-command nil "biome" "biome")
  command-execute(execute-extended-command)
```